### PR TITLE
Log4j CVE-2021-44228 patch 2.6.2 to 2.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file, from 0.2.0.
 
+## [5.3.1] - 2024-05-17
+  - Log4j CVE-2021-44228 patch 2.6.2 to 2.12.2
+
 ## [5.3.0] - 2017-11-08
   - Adds configuration options `enable_event_as_json_keyword` and `event_as_json_keyword`
   - Adds BigDecimal support

--- a/logstash-output-jdbc.gemspec
+++ b/logstash-output-jdbc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-jdbc'
-  s.version = '5.4.0'
+  s.version = '5.4.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = 'This plugin allows you to output to SQL, via JDBC'
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install 'logstash-output-jdbc'. This gem is not a stand-alone program"
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
 
   s.requirements << "jar 'com.zaxxer:HikariCP', '2.7.2'"
-  s.requirements << "jar 'org.apache.logging.log4j:log4j-slf4j-impl', '2.6.2'"
+  s.requirements << "jar 'org.apache.logging.log4j:log4j-slf4j-impl', '2.12.2'"
 
   s.add_development_dependency 'jar-dependencies'
   s.add_development_dependency 'ruby-maven', '~> 3.3'


### PR DESCRIPTION
Log4j CVE-2021-44228 patch 2.6.2 to 2.12.2